### PR TITLE
feat(news): add positive scenario create news

### DIFF
--- a/cypress/e2e/news_articles/news/publish.cy.js
+++ b/cypress/e2e/news_articles/news/publish.cy.js
@@ -7,6 +7,8 @@ let listPage = new ListNewsPage()
 let createPage = new CreateNewsPage()
 let dataUpload
 let dataLive
+let dataCategory
+let dataLocation
 
 beforeEach('', () => {
     cy.intercept({ resourceType: /xhr|fetch/ }, { log: false })
@@ -20,6 +22,12 @@ before('Load Data', () => {
     cy.fixture("news_articles/news/data_live.json").then((data) => {
         dataLive = data
     })
+    cy.fixture("news_articles/news/data_category.json").then((data) => {
+        dataCategory = data
+    })
+    cy.fixture("news_articles/news/data_location.json").then((data) => {
+        dataLocation = data
+    })
 })
 
 beforeEach('', () => {
@@ -29,14 +37,33 @@ beforeEach('', () => {
 })
 
 describe('Scenario Publish News Positive', { testIsolation: false }, () => {
-    qase([],
+    qase([334, 1521, 339, 340, 342, 329],
         it('Publish News', () => {
+            // Navigate to form add
             listPage.clickBtnCreateNews()
             createPage.assertCreatePage()
+
+            // Form Input
             createPage.inputTitleNews(faker.word.adverb())
             createPage.uploadFileBanner(dataUpload.img1500x500)
             createPage.inputNewsContent(faker.lorem.sentences(5))
             createPage.chooseLiveDuration(dataLive.tanpaBatas)
+            createPage.chooseCategoryTopic(dataCategory.cat1)
+            createPage.enterTag()
+            createPage.assertTags()
+            createPage.inputAuthor(faker.lorem.word(5))
+            createPage.inputReporter(faker.lorem.word(7))
+            createPage.inputEditor(faker.lorem.word(9))
+            createPage.chooseLocations(dataLocation.kotCimahi)
+
+            // Btn Publish Actions
+            createPage.clickBtnPublish()
+            createPage.clickBtnYesPublish()
+            createPage.clickBtnCloseModals()
+
+            // Assert data in list data news
+            listPage.navigateToNewsTab()
+            listPage.assertNewData()
         })
     )
 })

--- a/cypress/support/pages/news_articles/news/create.cy.js
+++ b/cypress/support/pages/news_articles/news/create.cy.js
@@ -62,4 +62,177 @@ export class CreateNewsPage {
             }
         })
     }
+
+    chooseCategoryTopic(valueTopic) {
+        // Dropdown
+        const dropdown = cy.xpath(create.dropdown_categoryTopic)
+        dropdown.click()
+        cy.wait(1000)
+
+        // Choose Category
+        const category = cy.contains(valueTopic)
+        category.click()
+
+        cy.readFile(data).then((object) => {
+            object.categoryTopic = valueTopic
+            cy.writeFile(data, object)
+        })
+
+        // Assertion Choose Option Category
+        const value = cy.xpath("//input[@placeholder='Pilih kategori/topik']")
+        value.invoke("val").then((text) => {
+            if (text == "") {
+                expect("").to.equal(text)
+            } else {
+                expect(valueTopic).to.equal(text)
+            }
+        })
+    }
+
+    enterTag() {
+        let tagData = "cypress/fixtures/agenda/agenda_data.json"
+        let formInputTag = cy.get(create.input_tag)
+
+        cy.readFile(tagData).then((object) => {
+            const dataTag = [
+                {
+                    tag: object.tagAgenda1,
+                },
+                {
+                    tag: object.tagAgenda2,
+                },
+                {
+                    tag: object.tagAgenda3,
+                },
+            ]
+
+            dataTag.forEach(({ tag }) => {
+                formInputTag.type(tag + "{enter}")
+            })
+        })
+    }
+
+    assertTags() {
+        let tagData = "cypress/fixtures/agenda/agenda_data.json"
+
+        cy.readFile(tagData).then((object) => {
+            const sectionTag = cy.xpath(create.section_tag)
+            sectionTag.should('contain', object.tagAgenda1)
+                .and('contain', object.tagAgenda2)
+                .and('contain', object.tagAgenda3)
+        })
+    }
+
+    inputAuthor(text) {
+        const formInput = cy.get(create.input_author)
+
+        cy.readFile(data).then((object) => {
+            object.author = text
+            cy.writeFile(data, object)
+        })
+
+        formInput.type(text)
+    }
+
+    inputReporter(text) {
+        const formInput = cy.get(create.input_reporter)
+
+        cy.readFile(data).then((object) => {
+            object.reporter = text
+            cy.writeFile(data, object)
+        })
+
+        formInput.type(text)
+    }
+
+    inputEditor(text) {
+        const formInput = cy.get(create.input_editor)
+
+        cy.readFile(data).then((object) => {
+            object.editor = text
+            cy.writeFile(data, object)
+        })
+
+        formInput.type(text)
+    }
+
+    chooseLocations(valueLocation) {
+        // Dropdown
+        const dropdown = cy.xpath(create.dropdown_location)
+        dropdown.click()
+        cy.wait(1000)
+
+        // Choose Locations
+        const location = cy.contains(valueLocation)
+        location.click()
+
+        cy.readFile(data).then((object) => {
+            object.location = valueLocation
+            cy.writeFile(data, object)
+        })
+
+        // Assertion Choose Option Locations
+        const value = cy.xpath("//input[@placeholder='Pilih lokasi']")
+        value.invoke("val").then((text) => {
+            if (text == "") {
+                expect("").to.equal(text)
+            } else {
+                expect(valueLocation).to.equal(text)
+            }
+        })
+    }
+
+    // Btn Action
+    clickBtnPublish() {
+        const btn = cy.xpath(create.btn_publish)
+        btn.then(($btn) => {
+            if ($btn.is(":disabled")) {
+                btn.should("be.disabled")
+            } else {
+                btn.should("be.visible")
+                btn.contains("Ajukan untuk Diterbitkan")
+                btn.click()
+                cy.wait(2000)
+                // Assertion Modals Confirmation
+                const titleModals = cy.xpath(create.modals_title)
+                titleModals.should('contain', 'Terbitkan Berita')
+
+                const bodyModals = cy.xpath(create.modals_body)
+                bodyModals.should('contain', 'Apakah Anda yakin untuk mengajukan berita ini untuk diterbitkan?')
+
+                cy.readFile(data).then((object) => {
+                    const titleNewsConfirmation = cy.xpath(create.modals_NewsTitleConfirmation)
+                    titleNewsConfirmation.should('contain', object.titleNews)
+                })
+            }
+        })
+    }
+
+    clickBtnYesPublish() {
+        const btn = cy.xpath(create.btn_yesPublish)
+        const assertion = "Menunggu Review"
+
+        btn.click()
+        cy.wait(2000)
+
+        // Assert Success Publish Data
+        const titleSuccess = cy.xpath(create.modals_title)
+        titleSuccess.should('contain', 'Ajukan Berita Berhasil')
+
+        const messageSuccess = cy.xpath(create.modals_bodyConfirmation)
+        messageSuccess.should('contain', 'Berita yang Anda buat sedang menunggu untuk direview.')
+
+        // Status Data 
+        cy.readFile(data).then((object) => {
+            object.status = assertion
+            cy.writeFile(data, object)
+        })
+    }
+
+    clickBtnCloseModals() {
+        const btn = cy.get(create.btn_close)
+        btn.click()
+        cy.wait(2000)
+        cy.url().should("eq", Cypress.env("base_url") + "/berita-dan-artikel")
+    }
 }

--- a/cypress/support/pages/news_articles/news/list.cy.js
+++ b/cypress/support/pages/news_articles/news/list.cy.js
@@ -2,6 +2,8 @@ import navbar from "../../../selectors/navbar"
 import sidebar from "../../../selectors/sidebar"
 import list from "../../../selectors/news_articles/news/list"
 
+const data = "cypress/fixtures/news_articles/news/data_news.json"
+
 export class ListNewsPage {
     assertPage() {
         // Title
@@ -45,5 +47,18 @@ export class ListNewsPage {
         const btn = cy.contains(list.btnAdd)
         btn.click()
         cy.wait(5000)
+    }
+
+    assertNewData() {
+        const data = "cypress/fixtures/news_articles/news/data_news.json"
+
+        cy.readFile(data).then((object) => {
+            const newData = cy.xpath(list.tr_rowNewData)
+            const lowerCategoryTopic = object.categoryTopic.toLowerCase()
+
+            newData.should('contain', object.titleNews)
+                .and('contain', lowerCategoryTopic)
+                .and('contain', object.status)
+        })
     }
 }

--- a/cypress/support/selectors/news_articles/news/create.js
+++ b/cypress/support/selectors/news_articles/news/create.js
@@ -3,16 +3,30 @@ module.exports = {
     textarea_titleNews: '//textarea[@placeholder="Masukkan judul berita"]',
     input_fileUpload: '//input[@type="file"]',
     textarea_newsContent: '/html[1]/body[1]/div[1]/div[1]/div[1]/div[1]/main[1]/form[1]/div[1]/div[4]',
+    input_tag: '#tag',
+    section_tag: '/html[1]/body[1]/div[1]/div[1]/div[1]/div[1]/main[1]/form[1]/div[2]/div[2]/div[1]/div[1]/div[2]/div[2]',
     input_author: '#author',
     input_reporter: '#reporter',
     input_editor: '#editor',
     dropdown_durationLive: '/html[1]/body[1]/div[1]/div[1]/div[1]/div[1]/main[1]/form[1]/div[2]/div[1]/div[1]/div[1]/div[1]/div[1]/div[1]/div[1]/div[1]',
+    dropdown_categoryTopic: '/html[1]/body[1]/div[1]/div[1]/div[1]/div[1]/main[1]/form[1]/div[2]/div[2]/div[1]/div[1]/div[1]/div[1]/div[1]/div[1]/div[1]',
     dropdown_location: '/html[1]/body[1]/div[1]/div[1]/div[1]/div[1]/main[1]/form[1]/div[2]/div[3]/div[1]/div[1]/div[4]/div[1]/div[1]/div[1]/div[1]',
     // Form
 
     // Btn Action
     btn_preview: '/html[1]/body[1]/div[1]/div[1]/div[1]/div[1]/main[1]/section[1]/div[2]/div[1]/button[1]',
     btn_publish: '/html[1]/body[1]/div[1]/div[1]/div[1]/div[1]/main[1]/section[1]/div[2]/div[1]/button[2]',
-    btn_save: '/html[1]/body[1]/div[1]/div[1]/div[1]/div[1]/main[1]/section[1]/div[2]/div[1]/button[3]'
+    btn_save: '/html[1]/body[1]/div[1]/div[1]/div[1]/div[1]/main[1]/section[1]/div[2]/div[1]/button[3]',
     // Btn Action
+
+    // Btn Modals
+    btn_yesPublish: '/html[1]/body[1]/div[1]/div[2]/div[1]/section[1]/div[3]/div[1]/button[2]',
+    btn_close: '[data-cy="modal-footer__close-button"]',
+
+    // Modals
+    modals_title: '/html[1]/body[1]/div[1]/div[2]/div[1]/section[1]/div[2]/div[1]/h1[1]',
+    modals_body: '/html[1]/body[1]/div[1]/div[2]/div[1]/section[1]/div[2]/div[1]/div[1]/div[1]/p[1]',
+    modals_bodyConfirmation: '/html[1]/body[1]/div[1]/div[2]/div[1]/section[1]/div[2]/div[1]/div[1]/p[1]',
+    modals_NewsTitleConfirmation: '/html[1]/body[1]/div[1]/div[2]/div[1]/section[1]/div[2]/div[1]/div[1]/div[1]/p[2]'
+
 }

--- a/cypress/support/selectors/news_articles/news/list.js
+++ b/cypress/support/selectors/news_articles/news/list.js
@@ -3,6 +3,7 @@ module.exports = {
     tabNews: '/html[1]/body[1]/div[1]/div[1]/div[1]/div[1]/div[1]/ul[1]/li[1]',
     textNews: '/html[1]/body[1]/div[1]/div[1]/div[1]/div[1]/div[1]/ul[1]/li[1]/p[1]',
     tabAgregation: '/html[1]/body[1]/div[1]/div[1]/div[1]/div[1]/div[1]/main[1]/section[1]/ul[1]',
+    tr_rowNewData: "(//tr)[2]",
 
     // Contains 
     btnAdd: 'Tambah Berita',


### PR DESCRIPTION
### Related
https://app.clickup.com/t/860rrxgta

### Overview
create news - positive scenario

### Changes
- add pages list data news
- update pages form add news ()
- update selectors list data news
- update selectors form add news
- complete e2e scneario add news 
- add test case id (qase.io)

### Evidence
project: Portal Jabar
title: create news - positive scenario
participants: @fauziMK @wulanLastia @farrasnaufalwork
lampiran: https://i.ibb.co/v4Q2bXB/Screenshot-2023-09-13-at-16-13-06.png