### PR TITLE
feat(news): define btn action in list data

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -28,7 +28,7 @@ module.exports = defineConfig({
     // Integration With Qase.io
     "reporter": "cypress-qase-reporter",
     "reporterOptions": {
-      "apiToken": process.env.QASE_IO_API_TOKEN,
+      "apiToken": process.env.QASE_IO_API_KEY,
       "projectCode": "IPJ",
       "logging": true,
       "runComplete": true,

--- a/cypress/e2e/news_articles/news/publish.cy.js
+++ b/cypress/e2e/news_articles/news/publish.cy.js
@@ -32,13 +32,14 @@ before('Load Data', () => {
 
 beforeEach('', () => {
     cy.login()
+    cy.intercept({ resourceType: /xhr|fetch/ }, { log: false })
     listPage.navigateToNewsArchiveMenu()
     listPage.navigateToNewsTab()
 })
 
-describe('Scenario Publish News Positive', { testIsolation: false }, () => {
+describe('Scenario Publish News Positive', { testIsolation: true }, () => {
     qase([334, 1521, 339, 340, 342, 329],
-        it('Publish News', () => {
+        it('Create News Data', () => {
             // Navigate to form add
             listPage.clickBtnCreateNews()
             createPage.assertCreatePage()
@@ -64,6 +65,12 @@ describe('Scenario Publish News Positive', { testIsolation: false }, () => {
             // Assert data in list data news
             listPage.navigateToNewsTab()
             listPage.assertNewData()
+        })
+    )
+
+    qase([],
+        it('Preview Data', () => {
+            listPage.clickBtnAksi()
         })
     )
 })

--- a/cypress/support/pages/news_articles/news/list.cy.js
+++ b/cypress/support/pages/news_articles/news/list.cy.js
@@ -65,7 +65,6 @@ export class ListNewsPage {
     // Btn Aksi
     clickBtnAksi() {
         const btnAksi = cy.xpath(list.btn_Action)
-        // btnAksi.should("be.visible")
         btnAksi.should("contain", "Aksi")
         btnAksi.click({ force: true })
         cy.wait(2000)

--- a/cypress/support/pages/news_articles/news/list.cy.js
+++ b/cypress/support/pages/news_articles/news/list.cy.js
@@ -61,4 +61,34 @@ export class ListNewsPage {
                 .and('contain', object.status)
         })
     }
+
+    // Btn Aksi
+    clickBtnAksi() {
+        const btnAksi = cy.xpath(list.btn_Action)
+        // btnAksi.should("be.visible")
+        btnAksi.should("contain", "Aksi")
+        btnAksi.click({ force: true })
+        cy.wait(2000)
+    }
+
+    clickBtnDetail() {
+        const btnDetail = cy.xpath(list.btn_Detail)
+        btnDetail.should("contain", "Detail")
+        btnDetail.click({ force: true })
+        cy.wait(2000)
+    }
+
+    clickBtnUbah() {
+        const btnUbah = cy.xpath(list.btn_Update).as('clickBtnUbah')
+        btnUbah.should("contain", "Ubah")
+        btnUbah.click({ force: true })
+        cy.wait(2000)
+    }
+
+    clickBtnDelete() {
+        const btnDelete = cy.get(list.btn_Delete)
+        btnDelete.should("contain", "Hapus")
+        btnDelete.click({ force: true })
+    }
+    // End Btn Aksi
 }

--- a/cypress/support/selectors/news_articles/news/list.js
+++ b/cypress/support/selectors/news_articles/news/list.js
@@ -5,6 +5,12 @@ module.exports = {
     tabAgregation: '/html[1]/body[1]/div[1]/div[1]/div[1]/div[1]/div[1]/main[1]/section[1]/ul[1]',
     tr_rowNewData: "(//tr)[2]",
 
+    // btn action
+    btn_Action: "(//button[contains(text(),'Aksi')])[1]",
+    btn_Detail: '/html[1]/body[1]/div[1]/div[1]/div[1]/div[1]/div[1]/main[1]/section[1]/div[1]/div[3]/div[1]/table[1]/tbody[1]/tr[1]/tr[1]/td[7]/div[1]/div[2]/div[1]/ul[1]/li[1]/a[1]',
+    btn_Update: '/html[1]/body[1]/div[1]/div[1]/div[1]/div[1]/div[1]/main[1]/section[1]/div[1]/div[3]/div[1]/table[1]/tbody[1]/tr[1]/tr[1]/td[7]/div[1]/div[2]/div[1]/ul[1]/li[2]/a[1]',
+    btn_Delete: '/html[1]/body[1]/div[1]/div[1]/div[1]/div[1]/div[1]/main[1]/section[1]/div[1]/div[3]/div[1]/table[1]/tbody[1]/tr[1]/tr[1]/td[7]/div[1]/div[2]/div[1]/ul[1]/li[3]/button[1]',
+
     // Contains 
     btnAdd: 'Tambah Berita',
 


### PR DESCRIPTION
### Related


### Overview
Cypress config & Define selectors btn

### Changes
- Config QASE.IO Token use .env
- define selector btn action

### Evidence
project: Portal Jabar
title: define btn action on list data news
participants: @fauziMK @wulanLastia @farrasnaufalwork
lampiran: https://i.ibb.co/v4Q2bXB/Screenshot-2023-09-13-at-16-13-06.png